### PR TITLE
fix: added 'img/' to the list of files copied into the installer

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     },
     "files": [
       "dist/",
+      "img/",
       "node_modules/",
       "app.html",
       "main.js",


### PR DESCRIPTION
Without this, the SVG images for install, uninstall, and upgrade were
missing.

Tested on MacOS Mojave