### PR TITLE
[#41] hide buttons during an install

### DIFF
--- a/app/app.global.scss
+++ b/app/app.global.scss
@@ -465,112 +465,125 @@ h2.ui.header {
 
 // button bar at the bottom
 .ui.steps {
-  background-color: white;
-  border: none;
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  width: 100%;
-  padding: 0.5rem 0;
-  min-height: 7rem;
-  border-radius: 0;
-  margin: 0;
-
-  .ui.button {
-    float: right;
-    min-height: 4rem;
-    position: absolute;
-    top: 1.5rem;
-    padding: 0;
-    font-size: $base-font;
-
-    &.secondary {
-      border: none;
-      left: 1.75rem;
-      padding: 0 1rem;
-    }
-
-    &.primary {
-      right: 1.75rem;
-      padding: 0 3.5rem;
-    }
-  }
-
-  .ui.message,
-  .ui.label {
+  
+  .step {
+    background-color: white;
     border: none;
-    background-color: transparent;
-    font-size: $base-sm;
-    font-family: $workbold;
-    text-align: center;
-    box-shadow: none;
-    padding: 0;
-    line-height: 1.2;
-    margin: 2.5rem auto 0;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    padding: 0.5rem 0;
+    min-height: 7rem;
+    border-radius: 0;
+    margin: 0;
+    z-index: 500;
+    box-shadow: 0 3px 10px rgba(30,30,30,0.5);
 
-    &.error {
-      color: darken($red, 12.5%);
+    // sneakyily hide the forward/back buttons during active install
+    &.progress-inactive {
+      z-index: 200;
     }
-  }
-
-  .ui.progress {
-    margin: 2rem auto 0;
-    min-width: 90%;
-    float: right;
-    background-color: transparent;
-
-    .label {
-      top: 0;
-      width: auto;
-      right: 0;
-      left: auto;
-      color: $navy;
+    &.progress-active {
+      z-index: 800;
     }
 
-    .bar {
-      margin-top: 0.425rem;
-      height: 0.75rem;
-      border-radius: 1rem;
-      background-image: linear-gradient(
-        to right,
-        $green,
-        $yellow,
-        $yellowl,
-        $bluel
-      );
-      @include transition;
+    .ui.button {
+      float: right;
+      min-height: 4rem;
+      position: absolute;
+      top: 1.5rem;
+      padding: 0;
+      font-size: $base-font;
 
-      &:after {
-        background: black;
+      &.secondary {
+        border: none;
+        left: 1.75rem;
+        padding: 0 1rem;
+      }
+
+      &.primary {
+        right: 1.75rem;
+        padding: 0 3.5rem;
       }
     }
 
-    &.success {
+    .ui.message,
+    .ui.label {
+      border: none;
+      background-color: transparent;
+      font-size: $base-sm;
+      font-family: $workbold;
+      text-align: center;
+      box-shadow: none;
+      padding: 0;
+      line-height: 1.2;
+      margin: 0.5rem auto 0;
+
+      &.error {
+        color: darken($red, 12.5%);
+      }
+    }
+
+    .ui.progress {
+      margin: 0 auto 0;
+      min-width: 90%;
+      float: right;
+      background-color: transparent;
+
       .label {
-        color: $green;
+        top: 0;
+        width: auto;
+        right: 0;
+        left: auto;
+        color: $navy;
       }
-      
+
       .bar {
+        margin-top: 0.425rem;
+        height: 0.75rem;
+        border-radius: 1rem;
         background-image: linear-gradient(
           to right,
+          $green,
+          $yellow,
           $yellowl,
-          $green
+          $bluel
         );
-      }
-    }
+        @include transition;
 
-    &.error {
-      .label {
-        color: $red;
+        &:after {
+          background: black;
+        }
       }
-      
-      .bar {
-        background-image: linear-gradient(
-          to right,
-          $yellowl,
-          $red
-        );
+
+      &.success {
+        .label {
+          color: $green;
+        }
+        
+        .bar {
+          background-image: linear-gradient(
+            to right,
+            $yellowl,
+            $green
+          );
+        }
+      }
+
+      &.error {
+        .label {
+          color: $red;
+        }
+        
+        .bar {
+          background-image: linear-gradient(
+            to right,
+            $yellowl,
+            $red
+          );
+        }
       }
     }
   }

--- a/app/components/Bundle.tsx
+++ b/app/components/Bundle.tsx
@@ -122,7 +122,9 @@ export default class Bundle extends React.Component<Properties, State, {}>  {
 
         <Segment>
           <Step.Group>
-            {this.dufflePanel()}
+            <Step>
+              {this.dufflePanel()}
+            </Step>
           </Step.Group>
         </Segment>
 

--- a/app/components/Installer.tsx
+++ b/app/components/Installer.tsx
@@ -170,17 +170,17 @@ export default class Installer extends React.Component<Properties, State, {}>  {
   private progress(): JSX.Element {
     switch (this.state.installProgress) {
       case InstallProgress.NotStarted:
-        return (<Label>Installation not yet started</Label>);
+        return (<Step className="progress-inactive"><Label>Installation not yet started</Label></Step>);
       case InstallProgress.Starting:
-        return (<Progress percent={10} active>Starting install</Progress>);
+        return (<Step className="progress-active"><Progress percent={10} active>Starting install</Progress></Step>);
       case InstallProgress.Importing:
-        return (<Progress percent={30} active>Importing images</Progress>);
+        return (<Step className="progress-active"><Progress percent={30} active>Importing images</Progress></Step>);
       case InstallProgress.Installing:
-        return (<Progress percent={85} active>Installing</Progress>);
+        return (<Step className="progress-active"><Progress percent={85} active>Installing</Progress></Step>);
       case InstallProgress.Succeeded:
-        return (<Progress percent={85} success>Install complete</Progress>);
+        return (<Step className="progress-active"><Progress percent={85} success>Install complete</Progress></Step>);
       case InstallProgress.Failed:
-        return (<Progress percent={85} error>Install failed: {this.state.installResult}</Progress>);
+        return (<Step className="progress-active"><Progress percent={85} error>Install failed: {this.state.installResult}</Progress></Step>);
     }
   }
 
@@ -207,9 +207,11 @@ export default class Installer extends React.Component<Properties, State, {}>  {
           </Segment>
           <Segment>
             <Step.Group>
-              <Button secondary left onclick={() => this.goBack()}><Icon name="angle left"></Icon> Cancel </Button>
+              <Step>
+                <Button secondary left onclick={() => this.goBack()}><Icon name="angle left"></Icon> Cancel </Button>
+                <Button primary right onClick={() => this.install()}>Install</Button>
+              </Step>
               {this.progress()}
-              <Button primary right onClick={() => this.install()}>Install</Button>
             </Step.Group>
           </Segment>
         </Form>

--- a/app/components/Report.tsx
+++ b/app/components/Report.tsx
@@ -35,9 +35,11 @@ export default class Report extends React.Component<Properties, State, {}>  {
         </Segment>
         <Segment raised>
           <Step.Group>
-            <Button secondary left onclick={() => this.goBack()}><Icon name="angle left"></Icon> Cancel </Button>
-            {this.postInstallPanel()}
-            {this.tryAgainButton()}
+            <Step>
+              <Button secondary left onclick={() => this.goBack()}><Icon name="angle left"></Icon> Cancel </Button>
+              {this.postInstallPanel()}
+              {this.tryAgainButton()}
+            </Step>
           </Step.Group>
         </Segment>
       </Container>


### PR DESCRIPTION
This is a bit of a hack - layering the progress bar over the Back/Install button panels, disabling them by crudely hiding them.

![https://media.giphy.com/media/ieREaX3VTHsqc/giphy.gif](https://media.giphy.com/media/ieREaX3VTHsqc/giphy.gif)

It gives the desired effect though. Closes #41.

---

Screenshots:

_transition when starting an install_

![install-start](https://user-images.githubusercontent.com/686194/49322467-b8714b00-f4c4-11e8-8341-791d19aba3f5.gif)

_during an install_

![install-mode](https://user-images.githubusercontent.com/686194/49322474-cb841b00-f4c4-11e8-81d2-c2e45a7302ab.gif)


