### PR TITLE
Interim fixes for embedding full bundles

### DIFF
--- a/app/components/Bundle.tsx
+++ b/app/components/Bundle.tsx
@@ -49,7 +49,7 @@ export default class Bundle extends React.Component<Properties, State, {}>  {
     const embeddedBundle = await embedded.bundle;
     const duffleBin = await findDuffleBinary(shell);
     const bundleManifest = map(embeddedBundle, (b) => b.manifest);
-    const hasFullBundle = embedded.hasFullBundle();
+    const hasFullBundle = await embedded.hasFullBundle();
     this.setState({
       bundleManifest: { ready: true, result: bundleManifest },
       duffle: { ready: true, result: duffleBin },

--- a/package.json
+++ b/package.json
@@ -75,6 +75,12 @@
       "buildResources": "resources",
       "output": "release"
     },
+    "extraResources": [
+      {
+        "from": "./data",
+        "to": "data"
+      }
+    ],
     "mac": {
       "extraResources": [
         {


### PR DESCRIPTION
Full bundle embedding was not working properly in the packaged environment (because Webpack).  This is a workaround where we use different embedding strategies in the dev and packaged environments.  It likely results in doubling up the TGZ and needs to be redone when we have more time.