### PR TITLE
[ui] styling form validation messages

### DIFF
--- a/app/app.global.scss
+++ b/app/app.global.scss
@@ -536,6 +536,7 @@ h2.ui.header {
       padding: 0;
       line-height: 1.2;
       margin: 0.5rem auto 0;
+      position: relative;
 
       &.error {
         color: darken($red, 12.5%);

--- a/app/app.global.scss
+++ b/app/app.global.scss
@@ -47,6 +47,21 @@ $yellowl: #FFF3E6;
   transition: $property $duration $easing;
 }
 
+@mixin affixLabel {
+  color: white;
+  padding: 0rem 0.66rem;
+  position: absolute;
+  left: 0.5rem;
+  line-height: 1.55;
+  margin-top: -1.75rem;
+  z-index: 1200;
+  background: $navy;
+  font-size: 0.825rem !important;
+  font-weight: bold;
+  border: 1px solid $navy;
+  border-radius: 0 0 0.25rem 0.25rem;
+}
+
 @mixin border-radius($radius1:3px, $radius2:3px) {
   -webkit-border-radius: $radius1 $radius2 $radius1 $radius2;
   -moz-border-radius: $radius1 $radius2 $radius1 $radius2;
@@ -347,6 +362,7 @@ h2.ui.header {
   padding: 0;
   line-height: 1.75;
   margin: 0 auto;
+  @include affixLabel;
 
   &.succeeded,
   &.verified {
@@ -613,6 +629,22 @@ form.ui.form {
     float: right;
     font-size: $base-sm;
     margin-bottom: -1rem;
+  }
+
+  .inline.field + .ui.message {
+    @include affixLabel;
+  }
+
+  .inline.field.error + .ui.message {
+    background: darken($red, 12.5%);
+    border-color: darken($red, 12.5%);
+  }
+
+  .segment:first-of-type > .segment {
+    
+    .field.error +.ui.message {
+      margin-top: -0.5rem !important;
+    }
   }
 
   label,

--- a/app/components/Installer.tsx
+++ b/app/components/Installer.tsx
@@ -157,12 +157,11 @@ export default class Installer extends React.Component<Properties, State, {}>  {
         <Form>
           <Segment>
             <Header sub>Install as</Header>
-            <Form.Group inline>
+            <Segment>
               <Form.Input inline key="installationName" name="installationName" label="Installation name" labelPosition="left" type="text" value={this.state.installationName} error={this.state.installationNameExists} onChange={this.handleNameChange} />
-            </Form.Group>
-            <Form.Group inline>
+              
               {...this.installationNameValidityPanel()}
-            </Form.Group>
+            </Segment>
           </Segment>
           <Segment>
             <Header sub>Installation parameters</Header>
@@ -192,10 +191,10 @@ export default class Installer extends React.Component<Properties, State, {}>  {
 
   private installationNameValidityPanel(): JSX.Element[] {
     if (this.state.installationNameExists === undefined) {
-      return [(<Message info>Checking installation name...</Message>)];
+      return [(<Message info inline>Checking installation name...</Message>)];
     }
     if (this.state.installationNameExists) {
-      return [(<Message>Name in use</Message>)];  // TODO: for some reason the 'error' option causes it not to show... ETA: it's because error blocks are shown only when the *form* is in an error state
+      return [(<Message inline>Name in use</Message>)];  // TODO: for some reason the 'error' option causes it not to show... ETA: it's because error blocks are shown only when the *form* is in an error state
     }
     return [];
   }


### PR DESCRIPTION
This updates the appearance and position of inline validation messages on the app installer form:

![validation-errors](https://user-images.githubusercontent.com/686194/63239266-48942380-c1ff-11e9-89bb-41ed043f05cd.gif)

* no longer hidden behind other fields
* validation messages no longer impact on their neighbors' position as they appear/disappear
* uses a bolder style, to differentiate from the plain text form labels