### PR TITLE
[ui] reduce font sizes

### DIFF
--- a/app/app.global.scss
+++ b/app/app.global.scss
@@ -144,13 +144,13 @@ $yellowl: #FFF3E6;
 
 // CNAB Typographic Scale
 // ---------------------------------------
-$base-font:  18px;                 // 18 - p
+$base-font:  16px;                 // 16 - p
 
-$base-xxxlg: ($base-font * 4.775); // 96
-$base-xxlg:  ($base-font * 2.4);   // 48
-$base-xlg:   ($base-font * 1.8);   // 36 - h3
-$base-lg:    ($base-font * 1.2);   // 24 - h4, p.lead
-$base-sm:    ($base-font * 0.875); // 18 - small
+$base-xxxlg: ($base-font * 4.25);  // 68
+$base-xxlg:  ($base-font * 2.4);   // 38.4
+$base-xlg:   ($base-font * 1.8);   // 28.8 - h3
+$base-lg:    ($base-font * 1.2);   // 19.2 - h4, p.lead
+$base-sm:    ($base-font * 0.875); // 14 - small
 
 
 html,


### PR DESCRIPTION
Reduces the size of all text / form fields / buttons / etc by 12%. Slight scale down of everything so that the viewport fits more content comfortably.

Before:

<img width="1136" alt="Screen Shot 2019-08-18 at 9 38 47 PM" src="https://user-images.githubusercontent.com/686194/63239608-de7c7e00-c200-11e9-843f-e03cacdc198f.png">

<img width="1136" alt="Screen Shot 2019-08-18 at 9 38 49 PM" src="https://user-images.githubusercontent.com/686194/63239615-e76d4f80-c200-11e9-9ea6-eab3c2376c29.png">

---

After:

<img width="1136" alt="Screen Shot 2019-08-18 at 9 39 14 PM" src="https://user-images.githubusercontent.com/686194/63239623-f05e2100-c200-11e9-862c-66ac1c3db81d.png">

<img width="1136" alt="Screen Shot 2019-08-18 at 9 39 18 PM" src="https://user-images.githubusercontent.com/686194/63239628-f48a3e80-c200-11e9-99ef-13f5ef48f4f5.png">

